### PR TITLE
Allow TypeScript imports to use single quotes

### DIFF
--- a/packages/import-sort-parser-typescript/src/index.ts
+++ b/packages/import-sort-parser-typescript/src/index.ts
@@ -96,7 +96,7 @@ function parseImportDeclaration(
 
   let type: ImportType = "import";
 
-  let moduleName = importDeclaration.moduleSpecifier.getText().replace(/"/g, "");
+  let moduleName = importDeclaration.moduleSpecifier.getText().replace(/["']/g, "");
 
   const imported: IImport = {
     start,


### PR DESCRIPTION
For example, an Angular CLI application, (these are configured to use single quotes only), will sort all imports in the absolute module section when using the "module" style.

Stripping out single and double quotes from module names in imports fixes this. 

I think that this might fix #10 also.
