### PR TITLE
Support single quote imports in typescript parser

### DIFF
--- a/packages/import-sort-parser-typescript/src/index.ts
+++ b/packages/import-sort-parser-typescript/src/index.ts
@@ -96,7 +96,7 @@ function parseImportDeclaration(
 
   let type: ImportType = "import";
 
-  let moduleName = importDeclaration.moduleSpecifier.getText().replace(/"/g, "");
+  let moduleName = importDeclaration.moduleSpecifier.getText().replace(/"|'/g, "");
 
   const imported: IImport = {
     start,


### PR DESCRIPTION
I've been days behind a bug where import-sort was working on every project except one. Turned out that the one where it didn't work was a typescript project with single quotes on import.

I accidentally added an import with double quotes and suddenly the extension worked.

I guess the offending line is this one where double quotes are removed but not single quotes.