### PR TITLE
Allow to pass any customized config to style api

### DIFF
--- a/packages/import-sort-cli/src/index.ts
+++ b/packages/import-sort-cli/src/index.ts
@@ -90,7 +90,8 @@ if (file) {
   let sortResult: ISortResult | undefined;
 
   try {
-    sortResult = sortImports(unsortedCode, config.parser!, config.style!, file);
+    const {parser, style, config: rawConfig} = config;
+    sortResult = sortImports(unsortedCode, parser!, style!, file, rawConfig.custom);
   } catch (e) {
     bail(`Failed to parse '${fileOrDirectory}'`);
   }
@@ -143,7 +144,8 @@ if (directory) {
       let sortResult: ISortResult | undefined;
 
       try {
-        sortResult = sortImports(unsortedCode, config.parser!, config.style!, file);
+        const {parser, style, config: rawConfig} = config;
+        sortResult = sortImports(unsortedCode, parser!, style!, file, rawConfig.custom);
       } catch (e) {
         return;
       }

--- a/packages/import-sort-config/src/index.ts
+++ b/packages/import-sort-config/src/index.ts
@@ -14,6 +14,7 @@ export interface IConfigByGlobs {
 export interface IConfig {
   parser?: string;
   style?: string;
+  custom?: any;
 }
 
 export interface IResolvedConfig {
@@ -102,6 +103,10 @@ function mergeConfigs(rawConfigs: Array<IConfig | undefined>): IConfig | undefin
 
     if (currentConfig.style) {
       config.style = currentConfig.style;
+    }
+
+    if (currentConfig.custom) {
+      config.custom = currentConfig.custom;
     }
 
     return config!;

--- a/packages/import-sort-style/src/index.ts
+++ b/packages/import-sort-style/src/index.ts
@@ -85,5 +85,5 @@ export interface IStyleItem {
 }
 
 export interface IStyle {
-  (styleApi: IStyleAPI, file?: string): Array<IStyleItem>;
+  (styleApi: IStyleAPI, file?: string, customConfig?: any): Array<IStyleItem>;
 }

--- a/packages/import-sort/src/index.ts
+++ b/packages/import-sort/src/index.ts
@@ -16,7 +16,7 @@ export interface ICodeChange {
 }
 
 export default function importSort(
-  code: string, rawParser: string | IParser, rawStyle: string | IStyle, file?: string
+  code: string, rawParser: string | IParser, rawStyle: string | IStyle, file?: string, custom?: any
 ): ISortResult {
   let parser: IParser | undefined;
   let style: IStyle;
@@ -37,11 +37,13 @@ export default function importSort(
     style = rawStyle as IStyle;
   }
 
-  return sortImports(code, parser!, style, file);
+  return sortImports(code, parser!, style, file, custom);
 }
 
-export function sortImports(code: string, parser: IParser, style: IStyle, file?: string): ISortResult {
-  const items = addFallback(style, file)(StyleAPI);
+export function sortImports(
+  code: string, parser: IParser, style: IStyle, file?: string, custom?: any
+): ISortResult {
+  const items = addFallback(style, file, custom)(StyleAPI);
 
   const buckets: Array<Array<IImport>> = items.map(() => []);
 
@@ -280,13 +282,13 @@ export function applyChanges(code: string, changes: Array<ICodeChange>): string 
   return changedCode;
 }
 
-function addFallback(style: IStyle, file?: string): IStyle {
+function addFallback(style: IStyle, file?: string, custom?: any): IStyle {
   return styleApi => {
     const items = [
       {separator: true},
       {match: styleApi.always},
     ];
 
-    return style(styleApi, file).concat(items);
+    return style(styleApi, file, custom).concat(items);
   };
 }


### PR DESCRIPTION
this enables the capability to make more customizable styles config, a simple
example is to sort module names defined as `resolve.alias`. We may need
to sort certain module names in some other manners.