### PR TITLE
Allow to customize default settings in import-sort-config

### DIFF
--- a/packages/import-sort-config/src/index.ts
+++ b/packages/import-sort-config/src/index.ts
@@ -34,8 +34,8 @@ export const DEFAULT_CONFIGS: IConfigByGlobs = {
   },
 };
 
-export function getConfig(extension: string, directory?: string): IResolvedConfig | undefined {
-  const defaultConfig = getConfigForExtension(DEFAULT_CONFIGS, extension);
+export function getConfig(extension: string, directory?: string, defaultSettings = DEFAULT_CONFIGS): IResolvedConfig | undefined {
+  const defaultConfig = getConfigForExtension(defaultSettings, extension);
   let packageConfig: IConfig | undefined;
 
   if (directory) {


### PR DESCRIPTION
With this devs can get it package configuration without default configuration.

Solves #41