### PR TITLE
Added support for named type imports

### DIFF
--- a/packages/import-sort-parser-babylon/src/index.ts
+++ b/packages/import-sort-parser-babylon/src/index.ts
@@ -113,9 +113,12 @@ export function parseImports(code: string): Array<IImport> {
       if (node.specifiers) {
         node.specifiers.forEach(specifier => {
           if (isImportSpecifier(specifier)) {
+            const type =
+              (specifier as any).importKind === "type" ? {type: true} : {};
             imported.namedMembers!.push({
               name: specifier.imported.name,
               alias: specifier.local.name,
+              ...type,
             });
           } else if (isImportDefaultSpecifier(specifier)) {
             imported.defaultMember = specifier.local.name;
@@ -197,15 +200,16 @@ function formatNamedMembers(
       "{" +
       eol +
       namedMembers
-        .map(({name, alias}, index) => {
+        .map(({name, alias, type}, index) => {
           const lastImport = index === namedMembers.length - 1;
           const comma = !useTrailingComma && lastImport ? "" : ",";
+          const typeModifier = type ? "type " : "";
 
           if (name === alias) {
-            return `${prefix}${name}${comma}` + eol;
+            return `${prefix}${typeModifier}${name}${comma}` + eol;
           }
 
-          return `${prefix}${name} as ${alias}${comma}` + eol;
+          return `${prefix}${typeModifier}${name} as ${alias}${comma}` + eol;
         })
         .join("") +
       "}"
@@ -218,12 +222,14 @@ function formatNamedMembers(
       "{" +
       space +
       namedMembers
-        .map(({name, alias}) => {
+        .map(({name, alias, type}) => {
+          const typeModifier = type ? "type " : "";
+
           if (name === alias) {
-            return `${name}`;
+            return `${typeModifier}${name}`;
           }
 
-          return `${name} as ${alias}`;
+          return `${typeModifier}${name} as ${alias}`;
         })
         .join(", ") +
       comma +

--- a/packages/import-sort-parser-babylon/test/index.ts
+++ b/packages/import-sort-parser-babylon/test/index.ts
@@ -1,12 +1,14 @@
 import "mocha";
+
 import {assert} from "chai";
-import {parseImports, formatImport} from "../src";
 import {IImport} from "import-sort-parser";
+
+import {formatImport, parseImports} from "../src";
 
 describe("parseImports", () => {
   it("should return imports", () => {
     const imports = parseImports(
-`
+      `
 import "a";
 import b from "b";
 import {c} from "c";
@@ -14,7 +16,8 @@ import d, {e} from "f";
 import g, {h as hh} from "i";
 import * as j from "k";
 import l, * as m from "o";
-`.trim());
+`.trim(),
+    );
 
     assert.equal(imports.length, 7);
 
@@ -67,13 +70,28 @@ import l, * as m from "o";
     assert.equal(imports[6].namespaceMember, "m");
   });
 
+  it("should return default type import", () => {
+    const imports = parseImports(
+      `
+import type p from 'q';
+`.trim(),
+    );
+
+    assert.equal(imports[0].type, "import-type");
+    assert.equal(imports[0].start, 0);
+    assert.equal(imports[0].end, imports[0].end);
+    assert.equal(imports[0].moduleName, "q");
+    assert.equal(imports[0].defaultMember, "p");
+  });
+
   it("should include nearby comments", () => {
     const imports = parseImports(
-`
+      `
 // Above
 import "a"; // Besides
 // Below
-`.trim());
+`.trim(),
+    );
 
     assert.equal(imports[0].start, 0);
     assert.equal(imports[0].end, 31);
@@ -81,13 +99,14 @@ import "a"; // Besides
 
   it("should include all comments", () => {
     const imports = parseImports(
-`
+      `
 // Above
 // Above
 import "a"; // Besides
 // Below
 // Below
-`.trim());
+`.trim(),
+    );
 
     assert.equal(imports[0].start, 0);
     assert.equal(imports[0].end, 40);
@@ -95,13 +114,14 @@ import "a"; // Besides
 
   it("should only include nearby comments", () => {
     const imports = parseImports(
-`
+      `
 // Above
 
 import "a"; // Besides
 
 // Below
-`.trim());
+`.trim(),
+    );
 
     assert.equal(imports[0].start, 10);
     assert.equal(imports[0].end, 10 + 22);
@@ -109,10 +129,11 @@ import "a"; // Besides
 
   it("should not include shebang", () => {
     const imports = parseImports(
-`
+      `
 #!/bin/sh
 import "a";
-`.trim());
+`.trim(),
+    );
 
     assert.equal(imports[0].start, 10);
     assert.equal(imports[0].end, 10 + 11);
@@ -120,7 +141,7 @@ import "a";
 
   it("should include all nearby but exclude far away comments", () => {
     const imports = parseImports(
-`
+      `
 // Above
 
 // Above
@@ -128,7 +149,8 @@ import "a"; // Besides
 // Below
 
 // Below
-`.trim());
+`.trim(),
+    );
 
     assert.equal(imports[0].start, 10);
     assert.equal(imports[0].end, 10 + 31);
@@ -136,10 +158,11 @@ import "a"; // Besides
 
   it("should not treat trailing comment on previous import as leading comment", () => {
     const imports = parseImports(
-`
+      `
 import "a"; // Besides
 import "b";
-`.trim());
+`.trim(),
+    );
 
     assert.equal(imports[0].start, 0);
     assert.equal(imports[0].end, 22);
@@ -147,12 +170,21 @@ import "b";
     assert.equal(imports[1].start, 23);
     assert.equal(imports[1].end, 1 + 22 + 11);
   });
+
+  it("should include type information for named type imports", () => {
+    const imports = parseImports(
+      `
+import {type a} from "x";
+`.trim(),
+    );
+
+    assert.equal(imports[0].namedMembers[0].type, true);
+  });
 });
 
 describe("formatImport", () => {
   it("should not change one-line imports", () => {
-    const actual =
-`
+    const actual = `
 import {a, b, c} from "xyz"
 `.trim();
 
@@ -168,8 +200,7 @@ import {a, b, c} from "xyz"
       ],
     };
 
-    const expected =
-`
+    const expected = `
 import {a, b, c} from "xyz"
 `.trim();
 
@@ -177,8 +208,7 @@ import {a, b, c} from "xyz"
   });
 
   it("should not change full multi-line imports with same indendation", () => {
-    const actual =
-`
+    const actual = `
 import {
   a,
   b,
@@ -198,8 +228,7 @@ import {
       ],
     };
 
-    const expected =
-`
+    const expected = `
 import {
   a,
   b,
@@ -211,8 +240,7 @@ import {
   });
 
   it("should change partial multi-line imports indented by 2 spaces", () => {
-    const actual =
-`
+    const actual = `
 import {a,
   b,
 c
@@ -231,8 +259,7 @@ c
       ],
     };
 
-    const expected =
-`
+    const expected = `
 import {
   a,
   b,
@@ -244,8 +271,7 @@ import {
   });
 
   it("should change partial multi-line imports indented by 4 spaces", () => {
-    const actual =
-`
+    const actual = `
 import {a,
     b,
 c
@@ -264,8 +290,7 @@ c
       ],
     };
 
-    const expected =
-`
+    const expected = `
 import {
     a,
     b,
@@ -277,8 +302,7 @@ import {
   });
 
   it("should preserve whitespace around braces in one-line imports", () => {
-    const actual =
-`
+    const actual = `
 import { a, b, c } from "xyz"
 `.trim();
 
@@ -294,9 +318,64 @@ import { a, b, c } from "xyz"
       ],
     };
 
-    const expected =
-`
+    const expected = `
 import { a, b, c } from "xyz"
+`.trim();
+
+    assert.equal(formatImport(actual, imported), expected);
+  });
+
+  it("should format named same-line type imports", () => {
+    const actual = `
+import { type a, type b, c } from "xyz"
+`.trim();
+
+    const imported: IImport = {
+      start: 0,
+      end: 40,
+      type: "import",
+      moduleName: "xyz",
+      namedMembers: [
+        {name: "a", alias: "a", type: true},
+        {name: "b", alias: "b", type: true},
+        {name: "c", alias: "c"},
+      ],
+    };
+
+    const expected = `
+import { type a, type b, c } from "xyz"
+`.trim();
+
+    assert.equal(formatImport(actual, imported), expected);
+  });
+
+  it("should format named multi-line type imports", () => {
+    const actual = `
+import {
+  type a,
+  type b,
+  c
+} from "xyz"
+`.trim();
+
+    const imported: IImport = {
+      start: 0,
+      end: 46,
+      type: "import",
+      moduleName: "xyz",
+      namedMembers: [
+        {name: "a", alias: "a", type: true},
+        {name: "b", alias: "b", type: true},
+        {name: "c", alias: "c"},
+      ],
+    };
+
+    const expected = `
+import {
+  type a,
+  type b,
+  c
+} from "xyz"
 `.trim();
 
     assert.equal(formatImport(actual, imported), expected);

--- a/packages/import-sort-parser/src/index.ts
+++ b/packages/import-sort-parser/src/index.ts
@@ -24,4 +24,5 @@ export type ImportType = "import" | "require" | "import-equals" | "import-type";
 export type NamedMember = {
   name: string;
   alias: string;
+  type?: boolean;
 };


### PR DESCRIPTION
This PR adds support for formatting named type imports.

Currently, named type imports like this 

```js
import { type X } from 'y'
```

are getting replaced with this since it doesn't handle the case for type imports

```js
import { X } from 'y'
```

Default type imports are already working through #25 
