### PR TITLE
Fix sortNamedMembers bug

### DIFF
--- a/packages/import-sort/src/index.ts
+++ b/packages/import-sort/src/index.ts
@@ -265,7 +265,7 @@ function sortNamedMembers(
 
   if (!Array.isArray(sort)) {
     const sortedImport = Object.assign({}, imported);
-    sortedImport.namedMembers.sort(sort as INamedMemberSorterFunction);
+    sortedImport.namedMembers = [...imported.namedMembers].sort(sort as INamedMemberSorterFunction);
     return sortedImport;
   }
 
@@ -288,7 +288,7 @@ function sortNamedMembers(
   };
 
   const sortedImport = Object.assign({}, imported);
-  sortedImport.namedMembers.sort(multiSort);
+  sortedImport.namedMembers = [...imported.namedMembers].sort(multiSort);
 
   return sortedImport;
 }


### PR DESCRIPTION
`./style.js`
```js
module.exports = ({ moduleName, name, unicode }) => [
  {
    match: moduleName((m) => m === 'lodash'),
    sortNamedMembers: name(unicode),
  },
  {
    match: moduleName((m) => m === 'material-ui'),
    sortNamedMembers: undefined, // Keep ordering untouched
  },
];
```

`./target.js`
```js
import {
  mapValues,
  mapKeys,
  fromPairs,
} from 'lodash';
import {
  Table,
  Button,
  Paper,
} from 'material-ui';
```

Previous `import-sort` produces the following result, which is incorrect:
```js
import {
  fromPairs,
  mapKeys,
  mapValues,
} from 'lodash';
import {
  Button,
  Paper,
  Table,
} from 'material-ui';
```

This PR produces:
```js
import {
  fromPairs,
  mapKeys,
  mapValues,
} from 'lodash';
import {
  Table,
  Button,
  Paper,
} from 'material-ui';
```