### PR TITLE
Error: 'pipelineOperator' requires 'proposal' option whose value should be one of: minimal

### DIFF
--- a/packages/import-sort-parser-babylon/package.json
+++ b/packages/import-sort-parser-babylon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "import-sort-parser-babylon",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "An import-sort parser based on the JavaScript parser Babylon.",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/import-sort-parser-babylon/src/index.ts
+++ b/packages/import-sort-parser-babylon/src/index.ts
@@ -32,7 +32,7 @@ const BABYLON_PLUGINS = [
   "bigInt",
   "optionalCatchBinding",
   "throwExpressions",
-  "pipelineOperator",
+  ["pipelineOperator", {proposal: "minimal"}],
   "nullishCoalescingOperator",
 ];
 


### PR DESCRIPTION
@renke 

Description: 
Can not run import-sort on my code, and the following error is happening for all files:
```
Error: 'pipelineOperator' requires 'proposal' option whose value should be one of: minimal
```
based on https://babeljs.io/docs/en/next/babel-plugin-proposal-pipeline-operator.html proposal option only can be 'minimal'

Environment:
- Create-react-app v2 (using babel 7)
- There is no .babelrc in my project (it is hidden in react-scripts v2)
- There is no usage of Pipeline in my code
