### PR TITLE
Keep typeof

### DIFF
--- a/packages/import-sort-parser-babylon/test/index.ts
+++ b/packages/import-sort-parser-babylon/test/index.ts
@@ -84,6 +84,20 @@ import type p from 'q';
     assert.equal(imports[0].defaultMember, "p");
   });
 
+  it("should return default typeof import", () => {
+    const imports = parseImports(
+      `
+import typeof p from 'q';
+`.trim(),
+    );
+
+    assert.equal(imports[0].type, "import-type-of");
+    assert.equal(imports[0].start, 0);
+    assert.equal(imports[0].end, imports[0].end);
+    assert.equal(imports[0].moduleName, "q");
+    assert.equal(imports[0].defaultMember, "p");
+  });
+
   it("should include nearby comments", () => {
     const imports = parseImports(
       `
@@ -179,6 +193,16 @@ import {type a} from "x";
     );
 
     assert.equal(imports[0].namedMembers[0].type, true);
+  });
+
+  it("should include type information for named type imports", () => {
+    const imports = parseImports(
+      `
+import {typeof a} from "x";
+`.trim(),
+    );
+
+    assert.equal(imports[0].namedMembers[0].type_of, true);
   });
 });
 

--- a/packages/import-sort-parser/src/index.ts
+++ b/packages/import-sort-parser/src/index.ts
@@ -19,10 +19,11 @@ export interface IImport {
   namedMembers: Array<NamedMember>;
 }
 
-export type ImportType = "import" | "require" | "import-equals" | "import-type";
+export type ImportType = "import" | "require" | "import-equals" | "import-type" | "import-type-of";
 
 export type NamedMember = {
   name: string;
   alias: string;
   type?: boolean;
+  type_of?: boolean;
 };

--- a/packages/import-sort/test/index.ts
+++ b/packages/import-sort/test/index.ts
@@ -736,3 +736,25 @@ import {
     assert.equal(applyChanges(code, changes), expected);
   });
 });
+
+describe("respect typeof (babylon, NO_BUCKET_STYLE)", () => {
+  it("should not remove typeof", () => {
+    const code =
+`
+import {typeof a} from "a";
+`.trim() + "\n";
+
+    const expected =
+`
+import {typeof a} from "a";
+`.trim() + "\n";
+
+    const result = sortImports(code, parser, NO_BUCKET_STYLE);
+
+    const actual = result.code;
+    const changes = result.changes;
+
+    assert.equal(actual, expected);
+    assert.equal(applyChanges(code, changes), expected);
+  });
+});


### PR DESCRIPTION
At the moment, `import-sort` will not correctly process `typeof` imports that are valid when using flow. I implemented the necessary changes, and added a couple of tests for it.