### PR TITLE
Add styling support for Flow's "import type" statements

### DIFF
--- a/packages/import-sort-style/src/index.ts
+++ b/packages/import-sort-style/src/index.ts
@@ -38,6 +38,8 @@ export interface IStyleAPI {
   isScopedModule: IMatcherFunction;
   isInstalledModule(baseFile: string): IMatcherFunction;
 
+  isTypeImportType: IMatcherFunction;
+
   startsWithUpperCase: IPredicateFunction;
   startsWithLowerCase: IPredicateFunction;
   startsWithAlphanumeric: IPredicateFunction;

--- a/packages/import-sort/src/style/StyleAPI.ts
+++ b/packages/import-sort/src/style/StyleAPI.ts
@@ -198,6 +198,10 @@ function isScopedModule(imported: IImport): boolean {
   return imported.moduleName.startsWith("@");
 }
 
+function isTypeImportType(imported: IImport): boolean {
+  return imported.type === "import-type";
+}
+
 function startsWithUpperCase(text: string): boolean {
   let start = text.charAt(0);
   return text.charAt(0) === start.toUpperCase();
@@ -285,6 +289,8 @@ const StyleAPI: IStyleAPI = {
   isAbsoluteModule,
   isScopedModule,
   isInstalledModule,
+
+  isTypeImportType,
 
   startsWithUpperCase,
   startsWithLowerCase,

--- a/packages/import-sort/test/index.ts
+++ b/packages/import-sort/test/index.ts
@@ -736,3 +736,53 @@ import {
     assert.equal(applyChanges(code, changes), expected);
   });
 });
+
+const TWO_BUCKETS_IMPORT_TYPE: IStyle = (styleApi: IStyleAPI): Array<IStyleItem> => {
+  const items: Array<IStyleItem> = [
+    {
+      match: styleApi.not(styleApi.isTypeImportType),
+      sort: styleApi.member(styleApi.naturally),
+    },
+    {
+      separator: true,
+    },
+    {
+      match: styleApi.always,
+      sort: styleApi.member(styleApi.naturally),
+      sortNamedMembers: styleApi.name(styleApi.naturally),
+    },
+  ];
+
+  return items;
+}
+
+describe("sortImports (babylon, TWO_BUCKETS_IMPORT_TYPE)", () => {
+  it("should sort code containing only imports", () => {
+    const code = 
+`
+import b from "./b";
+import type { tx, ty } from "./t2";
+import type { tb, ta } from "./t1";
+import a from "a";
+import c from "./c";
+`.trim() + "\n";
+
+    const expected = 
+`
+import a from "a";
+import b from "./b";
+import c from "./c";
+
+import type { ta, tb } from "./t1";
+import type { tx, ty } from "./t2";
+`.trim() + "\n";
+
+    const result = sortImports(code, parser, TWO_BUCKETS_IMPORT_TYPE);
+
+    const actual = result.code;
+    const changes = result.changes;
+
+    assert.equal(actual, expected);
+    assert.equal(applyChanges(code, changes), expected);
+  })
+})


### PR DESCRIPTION
It can be desirable to group `import type` statements together, e.g.:

```
import a from "a";
import b from "./b";
import c from "./c";

import type { ta, tb } from "./t1";
import type { tx, ty } from "./t2";
```

And moreover from just stylistic benefits, being able to group `import type` statements at the top would help work around a current bug in VSCode's "Auto Import" feature: https://github.com/flowtype/flow-for-vscode/issues/181

Apologies that the name is a little awkward, the overloaded use of the word "type" is already in the codebase:

```
type ImportType = "import" | "require" | "import-equals" | "import-type";
```

Open to suggestions for a better name though.  The current one (`isTypeImportType`) is meant to represent "is the type of this import statement `import type`?".