### PR TITLE
Add the possibility to use import-sort-ignore comment

### DIFF
--- a/packages/import-sort-parser-babylon/src/index.ts
+++ b/packages/import-sort-parser-babylon/src/index.ts
@@ -52,6 +52,11 @@ export function parseImports(code: string): Array<IImport> {
 
   const imports: Array<IImport> = [];
 
+  const ignore = (parsed.comments || [])
+  .some(comment => comment.value.match(/\simport-sort-ignore\s/g))
+
+  if (ignore) return imports
+
   traverse(parsed, {
     ImportDeclaration(path) {
       const node = path.node;


### PR DESCRIPTION
You can use `/* import-sort-ignore */` comment to prevent the next line from being sorted.

Solves https://github.com/renke/import-sort/issues/62
(I used @jquense code)