### PR TITLE
feat: allow specifying options to parser and style presets via config

### DIFF
--- a/packages/import-sort-config/src/index.ts
+++ b/packages/import-sort-config/src/index.ts
@@ -6,17 +6,21 @@ export interface IConfigByGlobs {
   [globs: string]: IConfig;
 }
 
+export interface IConfigItem {
+  module: string;
+  options: Record<string, unknown>;
+}
 export interface IConfig {
-  parser?: string;
-  style?: string;
-  options?: object;
+  parser?: string | IConfigItem;
+  style?: string | IConfigItem;
+  options?: Record<string, unknown>;
 }
 
 export interface IResolvedConfig {
   config: IConfig;
 
-  parser?: string;
-  style?: string;
+  parser?: IConfigItem;
+  style?: IConfigItem;
 }
 
 export const DEFAULT_CONFIGS: IConfigByGlobs = {
@@ -154,18 +158,30 @@ function resolveConfig(config: IConfig, directory?: string): IResolvedConfig {
   return resolvedConfig;
 }
 
-function resolveParser(module: string, directory?: string) {
-  return (
+function resolveParser(parser: string | IConfigItem, directory?: string) {
+  let module: string | undefined;
+  let options: Record<string, unknown> = {};
+  if (typeof parser === "object") ({module, options} = parser);
+  else module = parser;
+
+  module =
     resolveModule(`import-sort-parser-${module}`, directory) ||
-    resolveModule(module, directory)
-  );
+    resolveModule(module, directory);
+
+  return module ? {options, module} : undefined;
 }
 
-function resolveStyle(module: string, directory?: string) {
-  return (
+function resolveStyle(style: string | IConfigItem, directory?: string) {
+  let module: string | undefined;
+  let options: Record<string, unknown> = {};
+  if (typeof style === "object") ({module, options} = style);
+  else module = style;
+
+  module =
     resolveModule(`import-sort-style-${module}`, directory) ||
-    resolveModule(module, directory)
-  );
+    resolveModule(module, directory);
+
+  return module ? {options, module} : undefined;
 }
 
 function resolveModule(module: string, directory?: string): string | undefined {

--- a/packages/import-sort-config/test/fixtures/.importsortrc
+++ b/packages/import-sort-config/test/fixtures/.importsortrc
@@ -2,6 +2,12 @@
   "unprefixed": {
     "parser": "some-parser"
   },
+  "withoptions": {
+    "parser": {
+      "module": "some-parser",
+      "options": {"foo": "bar"}
+    }
+  },
   "shorthand": {
     "style": "test"
   },

--- a/packages/import-sort-config/test/index.ts
+++ b/packages/import-sort-config/test/index.ts
@@ -15,27 +15,40 @@ describe("default config", () => {
     const config = getConfig(".js");
 
     assert.equal(
-      config!.parser,
+      config!.parser!.module,
       resolve(__dirname, "import-sort-parser-babylon"),
     );
-    assert.equal(config!.style, resolve(__dirname, "import-sort-style-eslint"));
+    assert.equal(
+      config!.style!.module,
+      resolve(__dirname, "import-sort-style-eslint"),
+    );
   });
 
   it("should resolve shorthand module names", () => {
     const config = getConfig("shorthand", fixtures);
 
-    assert.equal(config!.style, resolve(fixtures, "import-sort-style-test"));
+    assert.equal(
+      config!.style!.module,
+      resolve(fixtures, "import-sort-style-test"),
+    );
   });
 
   it("should resolve relative modules", () => {
     const config = getConfig("relative", fixtures);
 
-    assert.equal(config!.style, resolve(fixtures, "./local-style.js"));
+    assert.equal(config!.style!.module, resolve(fixtures, "./local-style.js"));
   });
 
   it("should resolve any module", () => {
     const config = getConfig("unprefixed", fixtures);
 
-    assert.equal(config!.parser, resolve(fixtures, "some-parser"));
+    assert.equal(config!.parser!.module, resolve(fixtures, "some-parser"));
+  });
+
+  it.only("should resolve with options", () => {
+    const config = getConfig("withoptions", fixtures);
+
+    assert.equal(config!.parser!.module, resolve(fixtures, "some-parser"));
+    assert.equal(config!.parser!.options!.foo, "bar");
   });
 });

--- a/packages/import-sort/src/index.ts
+++ b/packages/import-sort/src/index.ts
@@ -20,12 +20,20 @@ export interface ICodeChange {
   note?: string;
 }
 
+export interface IOptions {
+  parserOptions?: object;
+
+  styleOptions?: object;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [option: string]: any;
+}
+
 export default function importSort(
   code: string,
   rawParser: string | IParser,
   rawStyle: string | IStyle,
   file?: string,
-  options?: object,
+  options?: IOptions,
 ): ISortResult {
   let style: IStyle;
 
@@ -52,14 +60,16 @@ export function sortImports(
   parser: IParser,
   style: IStyle,
   file?: string,
-  options?: object,
+  options?: IOptions,
 ): ISortResult {
+  const {parserOptions, styleOptions, ...rest}: IOptions = options || {};
   // eslint-disable-next-line
-  const items = addFallback(style, file, options || {})(StyleAPI);
+  const items = addFallback(style, file, {...rest, styleOptions})(StyleAPI);
 
   const buckets: IImport[][] = items.map(() => []);
 
   const imports = parser.parseImports(code, {
+    ...parserOptions,
     file,
   });
 


### PR DESCRIPTION
allows specifying all the config for each parser. in config, or via the API. @renke what do you think about these api changes? Should move towards closing #84 