### PR TITLE
Fix typo in  import-sort-parser-babylon

### DIFF
--- a/packages/import-sort-parser-babylon/src/index.ts
+++ b/packages/import-sort-parser-babylon/src/index.ts
@@ -185,7 +185,7 @@ export function parseImports(
             });
           } else if (isImportDefaultSpecifier(specifier)) {
             imported.defaultMember = specifier.local.name;
-          } else if (isImportNamespaceSpecifier) {
+          } else if (isImportNamespaceSpecifier(specifier)) {
             imported.namespaceMember = specifier.local.name;
           }
         });


### PR DESCRIPTION
Fix isImportNamespaceSpecifier not being called in  import-sort-parser-babylon