### PR TITLE
fix(sort): fixed Vue SFC adding newline before sorting imports

### DIFF
--- a/packages/import-sort/src/index.ts
+++ b/packages/import-sort/src/index.ts
@@ -181,7 +181,7 @@ export function sortImports(
   let afterChange: ICodeChange | undefined;
 
   // Collapse all whitespace into a single blank line
-  before = before.replace(/\s+$/, match => {
+  before = before.replace(/[\t\v\f\r \u00a0\u2000-\u200b\u2028-\u2029\u3000]+$/, match => {
     beforeChange = {
       start: start - match.length,
       end: start,

--- a/packages/import-sort/test/index.ts
+++ b/packages/import-sort/test/index.ts
@@ -630,7 +630,7 @@ import b from "b";
     assert.equal(applyChanges(code, changes), expected);
   });
 
-  it("should add a blank line after the shebang", () => {
+  it("should organiza imports after the shebang", () => {
     const code =
       `
 #!/usr/bin/env node
@@ -641,7 +641,6 @@ import a from "a";
     const expected =
       `
 #!/usr/bin/env node
-
 import a from "a";
 import b from "b";
 `.trim() + "\n";


### PR DESCRIPTION
First of all, thanks @renke to create this awesome package.

I'm using this package with my Vue project. I was able to add support to `.vue` files using `import-sort-parser-babel-vue` (https://www.npmjs.com/package/import-sort-parser-babel-vue) add-on.

But I faced a problem that a newline is added right after the `<script>` part, messing with default Vue ESLint  rules.

Original:
```html
<template>
  <div class="home">
    <img alt="Vue logo" src="../assets/logo.png" />
    <HelloWorld msg="Welcome to Your Vue.js + TypeScript App" />
  </div>
</template>

<script lang="ts">
import Vue from 'vue'
import HelloWorld from '@/components/HelloWorld.vue' // @ is an alias to /src

export default Vue.extend({
  name: 'Home',
  components: {
    HelloWorld
  }
})
</script>
```

Output:
```html
<template>
  <div class="home">
    <img alt="Vue logo" src="../assets/logo.png" />
    <HelloWorld msg="Welcome to Your Vue.js + TypeScript App" />
  </div>
</template>

<script lang="ts">
// <- eslint warning about invalid new line
import HelloWorld from '@/components/HelloWorld.vue' // @ is an alias to /src
import Vue from 'vue'

export default Vue.extend({
  name: 'Home',
  components: {
    HelloWorld
  }
})
</script>
```

Using my fix:
```html
<template>
  <div class="home">
    <img alt="Vue logo" src="../assets/logo.png" />
    <HelloWorld msg="Welcome to Your Vue.js + TypeScript App" />
  </div>
</template>

<script lang="ts">
import HelloWorld from '@/components/HelloWorld.vue' // @ is an alias to /src
import Vue from 'vue'

export default Vue.extend({
  name: 'Home',
  components: {
    HelloWorld
  }
})
</script>
```


While debugging, I found out this is due whitespace replacement before sorting imports. So I made a fix to make sure that will only replaces white-spaced chars and skip newlines.

For some reasons, I believe we should preserve newline characters in lines before sorting. I think this ia a behavior that sort-imports package should not deal with it.

